### PR TITLE
library-lint-build.yml: bump upload-artifact

### DIFF
--- a/.github/workflows/library-lint-build-test.yml
+++ b/.github/workflows/library-lint-build-test.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Upload ESLint report
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: eslint-reports
           path: eslint-reports

--- a/.github/workflows/library-lint-build-test.yml
+++ b/.github/workflows/library-lint-build-test.yml
@@ -93,6 +93,7 @@ jobs:
         with:
           name: eslint-reports
           path: eslint-reports
+          overwrite: true
         continue-on-error: true
 
       - name: Build


### PR DESCRIPTION
causing PRs to fail, we should use v4

![image](https://github.com/user-attachments/assets/f3decd4e-b512-4573-89e1-05ad8503e6da)
